### PR TITLE
manifest.jsへの追記

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_tree ../builds
+//= link tailwind.css


### PR DESCRIPTION
○内容
manifest.jsへ//= link tailwind.cssを追記
○理由
rspecでエラーが生じ、追記によってエラーが解消する可能性があるため。