### PR TITLE
S3に係る設定変更

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,7 +3,7 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  if Rails.env.production?  # 本番環境の場合はS3へアップロード
+  if (Rails.env.development? && ENV['S3_STORAGE']) || Rails.env.production? # 本番環境の場合はS3へアップロード
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'nao09012137-backet' # バケット名


### PR DESCRIPTION
○変更内容概要
環境変数【S3_STORAGE】の情報を本番環境AWS上にのみ持たせることで、
本番ではS3を使用し、ローカルではS3を使用しない設定へと変更する。