### PR TITLE
タグテーブル及びタグリレーションテーブルの追加

### DIFF
--- a/app/models/post_tag_relation.rb
+++ b/app/models/post_tag_relation.rb
@@ -1,0 +1,4 @@
+class PostTagRelation < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,5 @@
+class Tag < ApplicationRecord
+  has_many :post_tag_relations, dependent: :destroy
+  has_many :posts,through: :post_tag_relations 
+  validates :tag_name, presence:true, length:{maximum:10}
+end

--- a/db/migrate/20230923073115_create_tags.rb
+++ b/db/migrate/20230923073115_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+    add_index :tags, :name, unique:true
+  end
+end

--- a/db/migrate/20230923073523_create_post_tag_relations.rb
+++ b/db/migrate/20230923073523_create_post_tag_relations.rb
@@ -1,0 +1,11 @@
+class CreatePostTagRelations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :post_tag_relations do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :post_tag_relations, [:post_id,:tag_id],unique: true
+  end
+end

--- a/db/migrate/20230924053247_rename_name_column_to_tags.rb
+++ b/db/migrate/20230924053247_rename_name_column_to_tags.rb
@@ -1,0 +1,5 @@
+class RenameNameColumnToTags < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :tags, :name, :tag_name
+  end
+end


### PR DESCRIPTION
○修正内容
　・タグテーブルの追加
　・タグリレーションテーブルの追加
○詳細説明
　タグ機能を持たせるために、テーブルを追加したもの。　　
　タグリレーションテーブルに関しては、ポストテーブルとタグテーブルを繋ぐ中間テーブルとして作成。